### PR TITLE
slim down plugin size

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,5 +110,3 @@ bintray {
         }
     }
 }
-
-bintrayUpload.dependsOn build, sourcesJar, javadocJar


### PR DESCRIPTION
references: https://github.com/bluesliverx/grails-external-config-reload/issues/31

That gradle task dependencies line is responsible for the `uber-jar` being uploaded to bintray. Removing it, solves the issue. Javadoc and sources jar are still being uploaded.

I would appreciate for quick turnaround in publishing new version.